### PR TITLE
fix link file different disk drive

### DIFF
--- a/Commands.ps1
+++ b/Commands.ps1
@@ -135,7 +135,11 @@ function First-Setup() {
 
 function Setup-Profile() {
     Print-Info "  Setting up Profile..."
-    Run-And-Log Link-File "${PROFILE}" "${PWD}/Microsoft.PowerShell_profile.ps1"
+    if ("${PROFILE}"[0] -eq "${PWD}"[0]) {
+        Run-And-Log Link-File "${PROFILE}" "${PWD}/Microsoft.PowerShell_profile.ps1"
+    } else {
+        Run-And-Log cp "${PWD}/Microsoft.PowerShell_profile.ps1" "${PROFILE}"
+    }
     Print-Done "  :: Setup-Profile"
 }
 

--- a/Commands.ps1
+++ b/Commands.ps1
@@ -135,7 +135,7 @@ function First-Setup() {
 
 function Setup-Profile() {
     Print-Info "  Setting up Profile..."
-    Link-File "${PROFILE}" "Microsoft.PowerShell_profile.ps1"
+    Run-And-Log Link-File "${PROFILE}" "${PWD}/Microsoft.PowerShell_profile.ps1"
     Print-Done "  :: Setup-Profile"
 }
 


### PR DESCRIPTION
- Log Link-File and use absolute path with `${PWD}`.
- Copy when drive letter differs
